### PR TITLE
clarifying language around parts of a hub

### DIFF
--- a/_static/custom.css
+++ b/_static/custom.css
@@ -10,3 +10,11 @@ div.figure img {
 .interface-logos img {
     height: 60px;
 }
+
+div.current-hubs .card-body p {
+    margin: 0;
+}
+
+p.card-text {
+    width: 100%;
+}

--- a/_static/custom.css
+++ b/_static/custom.css
@@ -12,6 +12,10 @@ div.figure img {
 }
 
 div.current-hubs .card-body p {
+    font-size: 1.2em;
+}
+
+div.current-hubs .card-footer p {
     margin: 0;
 }
 

--- a/conf.py
+++ b/conf.py
@@ -66,37 +66,45 @@ hubs = safe_load(resp.text)
 # [Funded by: {hub["funder"]['name']}]({hub["funded_by"]['url']})
 # [Designed by: {hub["architect"]['name']}]({hub["designed_by"]['url']})
 entries = ""
-for hub in hubs["hubs"]:
-    # TEMPORARILY HARD-CODING
-    hub['operator'] = {
-        'name': "CloudBank",
-        'url': "https://cloudbank.org"
-    }
-    hub['funder'] = {
-        'name': "CloudBank",
-        'url': "https://cloudbank.org"
-    }
-    hub['architect'] = {
-        'name': "2i2c",
-        'url': "https://2i2c.org"
-    }
+for cluster in hubs["clusters"]:
 
-    entries += f"""
-    ---
-    [`{hub["domain"]}`](https://{hub["domain"]})
-    ^^^
-    
-    [{hub["org_name"]}]({hub["org_url"]})
+    for hub in cluster["hubs"]:
+        # TEMPORARILY HARD-CODING
+        if cluster["name"] == "2i2c":
+            operator = "2i2c"
+            operator_url = "https://2i2c.org"
+        else:
+            operator = "CloudBank"
+            operator_url = "https://cloudbank.org"
+        hub['operator'] = {
+            'name': operator,
+            'url': operator_url
+        }
+        hub['funder'] = {
+            'name': operator,
+            'url': operator_url
+        }
+        hub['architect'] = {
+            'name': "2i2c",
+            'url': "https://2i2c.org"
+        }
 
-    Hub Operator: [{hub["operator"]['name']}]({hub["operator"]['url']})
+        entries += f"""
+        ---      
+        [{hub["org_name"]}]({hub["org_url"]})
+        
+        [`{hub["domain"]}`](https://{hub["domain"]})
 
-    Hub Funder: [{hub["funder"]['name']}]({hub["funder"]['url']})
+        +++
+        Hub Operator: [{hub["operator"]['name']}]({hub["operator"]['url']})
 
-    Hub Architect: [{hub["architect"]['name']}]({hub["architect"]['url']})
-    """
-    # Whenever we get approval, can add this to include logos
-    # ^^^
-    # [![logo]({hub["org_logo"]})]({hub["org_url"]})
+        Hub Funder: [{hub["funder"]['name']}]({hub["funder"]['url']})
+
+        Hub Architect: [{hub["architect"]['name']}]({hub["architect"]['url']})
+        """
+        # Whenever we get approval, can add this to include logos
+        # ^^^
+        # [![logo]({hub["org_logo"]})]({hub["org_url"]})
 entries = dedent(entries)
 
 hubs_table = f"""

--- a/conf.py
+++ b/conf.py
@@ -61,16 +61,38 @@ from pathlib import Path
 
 resp = requests.get("https://raw.githubusercontent.com/2i2c-org/low-touch-hubs/master/hubs.yaml")
 hubs = safe_load(resp.text)
+# FOR WHEN WE HAVE THIS DATA:
+# [Operated by: {hub["operator"]['name']}]({hub["operated_by"]['url']})
+# [Funded by: {hub["funder"]['name']}]({hub["funded_by"]['url']})
+# [Designed by: {hub["architect"]['name']}]({hub["designed_by"]['url']})
 entries = ""
 for hub in hubs["hubs"]:
+    # TEMPORARILY HARD-CODING
+    hub['operator'] = {
+        'name': "CloudBank",
+        'url': "https://cloudbank.org"
+    }
+    hub['funder'] = {
+        'name': "CloudBank",
+        'url': "https://cloudbank.org"
+    }
+    hub['architect'] = {
+        'name': "2i2c",
+        'url': "https://2i2c.org"
+    }
+
     entries += f"""
     ---
-    [{hub["org_name"]}]({hub["org_url"]})
-    [Operated by: {hub["operated_by"]['name']}]({hub["operated_by"]['url']})
-    [Funded by: {hub["funded_by"]['name']}]({hub["funded_by"]['url']})
-    [Designed by: {hub["designed_by"]['name']}]({hub["designed_by"]['url']})
-    +++
     [`{hub["domain"]}`](https://{hub["domain"]})
+    ^^^
+    
+    [{hub["org_name"]}]({hub["org_url"]})
+
+    Hub Operator: [{hub["operator"]['name']}]({hub["operator"]['url']})
+
+    Hub Funder: [{hub["funder"]['name']}]({hub["funder"]['url']})
+
+    Hub Architect: [{hub["architect"]['name']}]({hub["architect"]['url']})
     """
     # Whenever we get approval, can add this to include logos
     # ^^^
@@ -79,8 +101,8 @@ entries = dedent(entries)
 
 hubs_table = f"""
 ```{{panels}}
-:container: full-width
-:column: col-4 py-2 text-center
+:container: full-width current-hubs
+:column: col-6 py-2 text-center
 :body: +d-flex flex-wrap align-items-center text-center
 {entries}
 ```

--- a/conf.py
+++ b/conf.py
@@ -66,6 +66,9 @@ for hub in hubs["hubs"]:
     entries += f"""
     ---
     [{hub["org_name"]}]({hub["org_url"]})
+    [Operated by: {hub["operated_by"]['name']}]({hub["operated_by"]['url']})
+    [Funded by: {hub["funded_by"]['name']}]({hub["funded_by"]['url']})
+    [Designed by: {hub["designed_by"]['name']}]({hub["designed_by"]['url']})
     +++
     [`{hub["domain"]}`](https://{hub["domain"]})
     """

--- a/infrastructure.md
+++ b/infrastructure.md
@@ -23,6 +23,17 @@ This content is meant for those familiar with cloud infrastructure and tools for
 📦 data
 : The data that is used by your 2i2c Hub is provided by you! 2i2c Hubs can connect with a variety of public data sources. We recommend using standard data structures or specifications via libraries like [Intake](https://intake.readthedocs.io/en/latest/).
 
+(people-behind-hubs)=
+## What people run the hubs?
+
+2i2c Hubs require a variety of expertise to design, deploy, and maintain.
+This roughly breaks down along the following roles:
+
+* **A Hub Operator** keeps the hub running from day to day and supports hub users with technical problems. These individuals are the first point-of-contact 
+* **A Community Champion** is the main connection to the community of users that a hub is meant to serve. They work with the hub architect and operator to ensure the hub meets the needs of each community.
+* **A Hub Architect** designs the infrastructure underlying a community of hubs, and manages initial deployments and customizations. They create the backbone of 2i2c Hub infrastructure.
+* **A Resource Provider** provides the cloud resources to run the hub infrastructure. Sometimes this is a cloud provider providing credits, sometimes a community pays for its cloud resources, other times it is 2i2c.
+
 ## Where are 2i2c Hubs configured?
 
 All of the configuration and deployment scripts for the 2i2c Hubs can be found at [this GitHub repository][low-touch-hubs]. This repository contains both the deployment code as well as documentation that explains how it works. It should be treated as "for advanced users only", and is provided for transparency and as a guide for the community to follow if they wish to manage their own infrastructure similar to 2i2c Hubs.

--- a/infrastructure.md
+++ b/infrastructure.md
@@ -30,9 +30,9 @@ This content is meant for those familiar with cloud infrastructure and tools for
 This roughly breaks down along the following roles:
 
 * **A Hub Operator** keeps the hub running from day to day and supports hub users with technical problems. These individuals are the first point-of-contact 
-* **A Community Champion** is the main connection to the community of users that a hub is meant to serve. They work with the hub architect and operator to ensure the hub meets the needs of each community.
-* **A Hub Architect** designs the infrastructure underlying a community of hubs, and manages initial deployments and customizations. They create the backbone of 2i2c Hub infrastructure.
-* **A Resource Provider** provides the cloud resources to run the hub infrastructure. Sometimes this is a cloud provider providing credits, sometimes a community pays for its cloud resources, other times it is 2i2c.
+* **Community Champions** are the main connections to the community of users that a hub serves. They work with the hub architect and operator to ensure the hub meets the needs of each community. They often have elevated abilities on the hub such as administrative and customization permissions.
+* **A Hub Architect** designs the infrastructure underlying a community of hubs, and manages initial deployments and customizations. They create the backbone of 2i2c Hub infrastructure and work with Hub Operators and Community Champions to ensure that it meets the needs of the community.
+* **A Resource Provider** provides the cloud resources to run the hub infrastructure. Sometimes this is a cloud provider providing credits, sometimes a community brings cloud resources it has purchased or been given, and other times it is 2i2c that handles purchasing for the community.
 
 ## Where are 2i2c Hubs configured?
 

--- a/use.md
+++ b/use.md
@@ -36,10 +36,10 @@ Ask a question ❓
 Each community participating in the 2i2c Hubs Pilot will get their own JupyterHub instance. These instances are running at a URL with the following form:
 
 ```
-<community-name>.<project-name>.2i2c.cloud
+<hub-name>.<community-name>.2i2c.cloud
 ```
 
-Each 2i2c Hub has a **community** (denoted by `<community-name>`) and a **project** (denoted by `<project-name>`). Projects are different collections of community hubs, and are generally run by different teams of operators and funded by different organizations.
+Each 2i2c Hub has **hub name** (denoted by `<hub-name>`) and a **community name** (denoted by `<community-name>`). Communities are collections of hubs around a particular community or collaboration. Each community infrastructure may be run by different teams. For more information, see [](people-behind-hubs).
 
 (include-content)=
 ## Include content in your hub

--- a/use.md
+++ b/use.md
@@ -16,7 +16,7 @@ Request an improvement ✨
 :classes: stretched-link
 
 ---
-Report a technical issue 🐛
+Report an issue 🐛
 ^^^
 ```{link-button} https://github.com/2i2c-org/pilot/issues/new?labels=bug&template=tech-support.md
 :text: Crashing sessions, broken webpages, etc.

--- a/use.md
+++ b/use.md
@@ -1,6 +1,9 @@
 # User Guide
 
 This page contains information about using and customizing your 2i2c Hubs.
+
+**Hub Support**
+
 If you'd like to connect with the Hubs support team, click one of the buttons below to open an issue.
 
 ````{panels}
@@ -27,6 +30,17 @@ Ask a question ❓
 ```
 ````
 
+(note-on-urls)=
+## A note on hub URLs
+
+Each community participating in the 2i2c Hubs Pilot will get their own JupyterHub instance. These instances are running at a URL with the following form:
+
+```
+<community-name>.<project-name>.2i2c.cloud
+```
+
+Each 2i2c Hub has a **community** (denoted by `<community-name>`) and a **project** (denoted by `<project-name>`). Projects are different collections of community hubs, and are generally run by different teams of operators and funded by different organizations.
+
 (include-content)=
 ## Include content in your hub
 
@@ -40,6 +54,11 @@ You can use `nbgitpuller` to generate a link to a public repository, or a file i
   - The link will be in the field just above your form.
 
 - **Share this link with your users**. Anybody can click an `nbgitpuller` link. If they have an account on the hub to which it points, then they'll get a copy of the content that you've linked to.
+
+:::{important,admonition} Double-check your hub URL
+Make sure that the hub URL you insert into the nbgitpuller form is correct! See [](note-on-urls) for more information.
+:::
+
 
 ```{link-button} http://nbgitpuller.link
 :text: Go to nbgitpuller.link


### PR DESCRIPTION
This adds some language about what personnel go into running a hub:

https://github.com/2i2c-org/pilot/pull/16/files#diff-8473c42eb2a18950a8d85fbc1792e59e00ecad952e8127c899466afb87cf5f3bR27

@yuvipanda @clcarson one of my goals here is to have a public record of the roles involved in running a hub for transparency's sake. It also explicitly makes a role for people that interface with user communities. What do you think?

As well as noting how the Hub URLs are made:

https://github.com/2i2c-org/pilot/pull/16/files#diff-7eb6b105fc3412594ace295e36e9d20ec63490c23d0fc559bf2e3f5cabee9ed3R34

In particular, there I break down the URLs like so:

`<hub-name>.<community-name>.2i2c.cloud`. I am curious what @yuvipanda thinks about this. I am imagining patterns like `<somehub>.utoronto.2i2c.cloud` and thus using `utoronto` as a Toronto-specific constellation of hubs (which is why I call that part of the URL `<community-name>`. That may be something we wanna change in the future but I wonder what you think about that designation.