### PR TITLE
📚 DOCS: Replacing repository name in a few places

### DIFF
--- a/administrators.md
+++ b/administrators.md
@@ -4,10 +4,10 @@
 
 ### The default environment
 
-By default your 2i2c Hub has several packages installed for Python and R. The environment for all pilot hubs is defined [in this folder](https://github.com/2i2c-org/low-touch-hubs/tree/master/image). It is a bit technical, but gives an idea of the kinds of libraries that are installed by default. In particular:
+By default your 2i2c Hub has several packages installed for Python and R. The environment for all pilot hubs is defined [in this folder](https://github.com/2i2c-org/pilot-hubs/tree/master/images/user). It is a bit technical, but gives an idea of the kinds of libraries that are installed by default. In particular:
 
-- For Python: [see this `environment.yml` file](https://github.com/2i2c-org/low-touch-hubs/blob/master/image/environment.yml) for common Python packages
-- For R: [see this `install.R` file](https://github.com/2i2c-org/low-touch-hubs/blob/master/image/install.R)
+- For Python: [see this `environment.yml` file](https://github.com/2i2c-org/pilot-hubs/tree/master/images/user/environment.yml) for common Python packages
+- For R: [see this `install.R` file](https://github.com/2i2c-org/pilot-hubs/tree/master/images/user)
 
 ### Customize the hub's environment
 

--- a/administrators.md
+++ b/administrators.md
@@ -7,7 +7,7 @@
 By default your 2i2c Hub has several packages installed for Python and R. The environment for all pilot hubs is defined [in this folder](https://github.com/2i2c-org/pilot-hubs/tree/master/images/user). It is a bit technical, but gives an idea of the kinds of libraries that are installed by default. In particular:
 
 - For Python: [see this `environment.yml` file](https://github.com/2i2c-org/pilot-hubs/tree/master/images/user/environment.yml) for common Python packages
-- For R: [see this `install.R` file](https://github.com/2i2c-org/pilot-hubs/tree/master/images/user)
+- For R: [see this `install.R` file](https://github.com/2i2c-org/pilot-hubs/tree/master/images/user/install.R)
 
 ### Customize the hub's environment
 

--- a/conf.py
+++ b/conf.py
@@ -59,7 +59,7 @@ from textwrap import dedent
 from yaml import safe_load
 from pathlib import Path
 
-resp = requests.get("https://raw.githubusercontent.com/2i2c-org/low-touch-hubs/master/hubs.yaml")
+resp = requests.get("https://raw.githubusercontent.com/2i2c-org/pilot-hubs/master/hubs.yaml")
 hubs = safe_load(resp.text)
 entries = ""
 for cluster in hubs["clusters"]:

--- a/infrastructure.md
+++ b/infrastructure.md
@@ -36,7 +36,7 @@ This roughly breaks down along the following roles:
 
 ## Where are 2i2c Hubs configured?
 
-All of the configuration and deployment scripts for the 2i2c Hubs can be found at [this GitHub repository][low-touch-hubs]. This repository contains both the deployment code as well as documentation that explains how it works. It should be treated as "for advanced users only", and is provided for transparency and as a guide for the community to follow if they wish to manage their own infrastructure similar to 2i2c Hubs.
+All of the configuration and deployment scripts for the 2i2c Hubs can be found at [this GitHub repository][pilot-hubs]. This repository contains both the deployment code as well as documentation that explains how it works. It should be treated as "for advanced users only", and is provided for transparency and as a guide for the community to follow if they wish to manage their own infrastructure similar to 2i2c Hubs.
 
 ## How could I deploy my own 2i2c Hub?
 
@@ -45,9 +45,9 @@ The 2i2c Hubs are all deployed according to best-practices as documented in the 
 - For smaller hubs with 5-50 users: [The Littlest JupyterHub Documentation](https://tljh.jupyter.org)
 - For larger hubs with 5-100+ users: [The JupyterHub for Kubernetes Documentation](https://z2jh.jupyter.org)
 
-In addition, we recommend checking out [this GitHub repository][low-touch-hubs], which contains the configuration and deployment scripts for all of the hubs offered under this pilot.
+In addition, we recommend checking out [this GitHub repository][pilot-hubs], which contains the configuration and deployment scripts for all of the hubs offered under this pilot.
 
-[low-touch-hubs]: https://github.com/2i2c-org/low-touch-hubs
+[pilot-hubs]: https://github.com/2i2c-org/pilot-hubs
 
 ## A list of current hubs
 


### PR DESCRIPTION
Some of these auto-redirect since the repository was renamed, but some of them have file paths which have changed and now 404 so I've just replaced them all. ~~I haven't actually tested the changes (sphinx blew up in my face) but I'll try to soon~~. EDIT: sphinx seems happy now.