### PR TITLE
Add email support

### DIFF
--- a/admin/howto/support.md
+++ b/admin/howto/support.md
@@ -2,51 +2,20 @@
 
 Hub engineers can provide support and debugging for issues that are related to the 2i2c Hub infrastructure. There are a few ways to get in touch listed below (in decreasing order of preference!)
 
-(support:issues)=
-## Via GitHub Issues
-
-We handle most support requests via [GitHub issues in the `pilot/` repository](https://github.com/2i2c-org/pilot/issues).
-This ensures that most support (and the resulting fixes) are done in a public place.
-
-To help you open the right issue, here are a few buttons you can click to quickly open a support request in the `pilot/` repository:
-
-````{panels}
-:container: full-width
-:column: col-4
-:card: border-1 text-center
-Request an improvement ✨
-^^^
-```{link-button} https://github.com/2i2c-org/pilot/issues/new?labels=enhancement&template=tech-request.md
-:text: Update/add packages, infrastructure, etc.
-:classes: stretched-link
-
----
-Report an issue 🐛
-^^^
-```{link-button} https://github.com/2i2c-org/pilot/issues/new?labels=bug&template=tech-support.md
-:text: Crashing sessions, broken webpages, etc.
-:classes: stretched-link
----
-Ask a question ❓
-^^^
-```{link-button} https://github.com/2i2c-org/pilot/issues/new?labels=question&template=questions.md
-:classes: stretched-link
-:text: Generic questions about the hub.
-```
-````
-
-:::{note}
-If you have a support question that shouldn't be in public, please [send a support email](support:email).
-:::
-
-(support:slack)=
-## Connect on Slack
-
-You're also welcome to connect with the 2i2c Hub Engineering team via [the 2i2c Slack](https://2i2c.slack.com) (in particular, check out the `#support` channel). If you don't have access to the Slack already, [open an issue in the pilot repository](https://github.com/2i2c-org/pilot/issues/new) and we're happy to give you access.
-
-
 (support:email)=
-## Send a support email
+## How do I ask for support?
 
-For support requests that should not be public, you can also [send the 2i2c engineering team an email via `support@2i2c.org`](mailto:support@2i2c.org).
-We prefer to handle support requests via public issue tracking, but understand that this is not always possible!
+Send all support requests as an email to [**`support@2i2c.org`**](mailto:support@2i2c.org).
+This is email will be routed to the 2i2c support team, and we will get back to you shortly!
+
+When you make a support request, please include as much information as possible in order to provide context needed to resolve your issue!
+
+## Who can ask for support?
+
+A **Community Representative** of a hub should be the one that surfaces support requests to the 2i2c Engineering Team.
+Before reaching out to 2i2c for support, this person should work with others in their community to understand the problem and to ensure that it is something that requires intervention from a 2i2c Engineer.
+
+## What kinds of things require support?
+
+2i2c Engineers are needed to support major infrastructure problems or enhancements.
+They are not needed for doing things like regular administrative tasks on a JupyterHub (see the other sections in this guide for how a Hub Administrator can accomplish these tasks instead).


### PR DESCRIPTION
Updates our Hub Administrator's guide so that we encourage the use of `support@2i2c.org` rather than github issues here.

Relates to https://github.com/2i2c-org/team-compass/issues/200