### PR TITLE
Add roadmap page

### DIFF
--- a/about/roadmap.md
+++ b/about/roadmap.md
@@ -21,10 +21,14 @@ That is more comprehensive and bigger in scope than any one initiative.
 
 Our goal for this initiative is to have **basic infrastructure that automates the deployment of Kubernetes clusters and JupyterHubs**.
 
+:::{admonition} Deliverables for this initiative
+You can find deliverables for this initiative at [this project board](https://github.com/orgs/2i2c-org/projects/10)
+:::
+
 This initiative has the following major areas of work:
 
 - **Automation** - Automation is a critical part of scaling a service and minimizing manual steps with human intervention. We need to automate deployment and configuration of critical tools to deploy JupyterHub on Kubernetes.
-- **Reporting and testing** - Hub Administrators and Engineers should not have to dig into infrastructure for basic information. We should build basic reporting mechanisms and testing infrastructure that reports back what is going on with our infrastructure.
+- **Reporting and Quality Assurance** - Hub Administrators and Engineers should be confident that hubs are battle-tested and should know quickly if things are not working as expected. We should build basic reporting mechanisms and testing infrastructure that reports back what is going on with our infrastructure, as well as basic processes to ensure the quality of our hub deployments.
 - **Basic hub setups** - Hub Administrators will want a basic environment that is useful to them. We need to make reasonable choices in Hub Infrastructure and the use-cases it enables.
 - **Basic customizability** - Hub Administrators will want to customize their infrastructure to a degree. We should build in basic customization and configuration that does not require intervention from a 2i2c Engineer.
 
@@ -33,7 +37,13 @@ This initiative has the following major areas of work:
 In addition to basic infrastructure, 2i2c also requires a service model that makes it possible for communities to use the infrastructure, and that ensures the reliability of the infrastructure.
 These largely require organizational, administrative, and team practices to operate and improve the Hub Service.
 
-Our goal for this initiative is to have **a working support and operations plan, a sales plan, team coordination practices, and administrative infrastructure to support this service. 
+Our goal for this initiative is to have **a working support and operations plan, a sales plan, team coordination practices, and administrative infrastructure to support this service.
+
+:::{admonition} Deliverables for this initiative
+You can find deliverables for this initiative at [this project board](https://github.com/orgs/2i2c-org/projects/15)
+:::
+
+This initiative has the following main areas of work:
 
 - **Administration** - In order to run a service that charges customers, we'll need an administrative process and infrastructure to handle the financial, legal, etc aspects. 
 - **Support and operations model** - The Hub Engineering team will need to coordinate Development and Operations of the hub service in partnership with those administering the service. This will require practices for coordination and prioritization.

--- a/about/roadmap.md
+++ b/about/roadmap.md
@@ -1,0 +1,41 @@
+# Roadmap
+
+{octicon}`clock` Updated **{sub-ref}`today`**
+
+This roadmap describes our major development priorities for the Managed JupyterHub Service.
+It is meant to give an idea of where we hope to focus our efforts in the next several months.
+Planning for this roadmap roughly follows a quarterly process, and items may be updated or changed as we learn more about the most important things to work on.
+Treat this roadmap as a reflection of interests, not as a concrete promise.
+
+Below we describe major initiatives that are currently active in the Managed Hub Service.
+
+## Hub infrastructure launch
+
+The Managed Hubs Service relies heavily on infrastructure that centralizes the configuration and deployment of many JupyterHub instances.
+Our first major project is to use [our Pilot JupyterHubs](https://pilot-hubs.2i2c.org/en/latest/reference/hubs.html) to drive development on this infrastructure stack.
+
+:::{note}
+We are also [using an issue](https://github.com/2i2c-org/pilot-hubs/issues/610) to track long-term infrastructure needs for this service across all cloud providers.
+That is more comprehensive and bigger in scope than any one initiative.
+:::
+
+Our goal for this initiative is to have **basic infrastructure that automates the deployment of Kubernetes clusters and JupyterHubs**.
+
+This initiative has the following major areas of work:
+
+- **Automation** - Automation is a critical part of scaling a service and minimizing manual steps with human intervention. We need to automate deployment and configuration of critical tools to deploy JupyterHub on Kubernetes.
+- **Reporting and testing** - Hub Administrators and Engineers should not have to dig into infrastructure for basic information. We should build basic reporting mechanisms and testing infrastructure that reports back what is going on with our infrastructure.
+- **Basic hub setups** - Hub Administrators will want a basic environment that is useful to them. We need to make reasonable choices in Hub Infrastructure and the use-cases it enables.
+- **Basic customizability** - Hub Administrators will want to customize their infrastructure to a degree. We should build in basic customization and configuration that does not require intervention from a 2i2c Engineer.
+
+## Hub service model
+
+In addition to basic infrastructure, 2i2c also requires a service model that makes it possible for communities to use the infrastructure, and that ensures the reliability of the infrastructure.
+These largely require organizational, administrative, and team practices to operate and improve the Hub Service.
+
+Our goal for this initiative is to have **a working support and operations plan, a sales plan, team coordination practices, and administrative infrastructure to support this service. 
+
+- **Administration** - In order to run a service that charges customers, we'll need an administrative process and infrastructure to handle the financial, legal, etc aspects. 
+- **Support and operations model** - The Hub Engineering team will need to coordinate Development and Operations of the hub service in partnership with those administering the service. This will require practices for coordination and prioritization.
+- **Sales model** - In order to receive funding for running hubs for communities, we'll need a sales and pricing model that lets us sign contracts.
+- **Documentation** - As this will be a public-facing service, it will be crucial that we build high-quality public-facing documentation that describes the service and infrastructure.

--- a/about/strategy.md
+++ b/about/strategy.md
@@ -54,6 +54,11 @@ We'll focus on the following cloud providers:
 - Amazon Web Services
 - Microsoft Azure
 
+In the short term, we favor deploying hubs on Google Cloud Platform.
+This is because GCP has the most stable Kubernetes offering of all of the cloud providers.
+We follow [team guidelines for when to deploy new Kubernetes clusters](ph:cluster:when-to-deploy).
+For new hubs that don't require their own Kubernetes cluster, we plan to run them on Google Cloud until our team has capacity to run more infrastructure across Azure and AWS.
+
 ### Why Jupyter and JupyterHub?
 
 - The Jupyter ecosystem is a collection of building blocks that are highly customizable and composable. They are popular and useful for many use-cases, but still require expertise to customize for a particular need. This is well-suited for 2i2c's skillset and the kind of service it wishes to provide.

--- a/admin/howto/manage-users.md
+++ b/admin/howto/manage-users.md
@@ -59,18 +59,27 @@ Alternatively, you can go to this URL in your browser:
 1. Click the {guilabel}`Add Users` button. The {guilabel}`Add Users` dialog box will pop up.
 2. Add one or more users, and hit the {guilabel}`Add Users` button to authorize all the users you just added.
 
+`````{grid}
+:class-container: full-width
+:padding: 0 0 0 5
 
-````{panels}
-:container: full-width
-:card: border-1
+````{grid-item-card} 
+:class-item: border-1
 ```{figure} ../../images/add-users-button.png
 The {guilabel}`Add Users` button in the Administrator Panel.
 ```
----
+````
+
+````{grid-item-card} 
+:class-item: border-1
+
 ```{figure} ../../images/add-users-form.png
 Fill in usernames and optionally make them administrators. You can add multiple users at once by putting a username on each line.
 ```
+
 ````
+`````
+
 
 ### Finding usernames
 

--- a/admin/howto/new-hub.md
+++ b/admin/howto/new-hub.md
@@ -13,9 +13,9 @@ See [the pilot hubs documentation](tc:roles:community-representative) for more d
 We use a GitHub issue template to ask a few questions about your hub deployment that will help us deploy it.
 Click the button below to go to the form:
 
-```{link-button} https://github.com/2i2c-org/pilot-hubs/issues/new?assignees=&labels=type%3A+hub&template=new-hub.yml&title=New+Hub%3A+%3CHub+name%3E
-:text: Go to new Hub Form
-:classes: btn-outline-primary
+```{button-link} https://github.com/2i2c-org/pilot-hubs/issues/new?assignees=&labels=type%3A+hub&template=new-hub.yml&title=New+Hub%3A+%3CHub+name%3E
+:color: primary
+Go to new Hub Form
 ```
 
 Feel free to communicate with the team members in that issue to help clarify how the infrastructure should be set up.

--- a/conf.py
+++ b/conf.py
@@ -14,7 +14,7 @@ master_doc = "index"
 extensions = [
     "myst_nb",
     "sphinx_copybutton",
-    "sphinx_panels",
+    "sphinx_design",
     "sphinx.ext.intersphinx",
     "sphinxext.rediraffe",
 ]

--- a/index.md
+++ b/index.md
@@ -23,8 +23,9 @@ These sections contain information about the service, our goals and strategy for
 ```{toctree}
 :maxdepth: 1
 :caption: About the Pilot
-about/strategy
 about/overview
+about/strategy
+about/roadmap
 about/infrastructure
 ```
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ myst-nb
 myst-parser[linkify]
 sphinx-copybutton
 sphinx-book-theme
-sphinx-panels
+sphinx-design
 requests
 pyyaml
 sphinxext-rediraffe


### PR DESCRIPTION
This is an attempt at encoding some of our medium-term plans in the form of a light roadmap in the user-facing Pilot Hubs documentation. This is basically broken down like this:

- I've defined two major initiatives that we are currently focusing on
- Each initiative has a project board, linked in the roadmap
- Each board has 2-4 key focus areas that define major groups of work for that initiative. Each of these is a column.
- Each column has several deliverables that make up our effort in the given focus area of the initiative.

This also addresses part of https://github.com/2i2c-org/team-compass/issues/229 .

In tandem with https://github.com/2i2c-org/team-compass/pull/240

# Tasks

- [ ] Feedback on whether we are missing any important focus areas or deliverables in the linked boards - are we missing any deliverables that are crucial for the goals of these initiatives?
- [ ] Feedback on whether we missing any high-level initiatives for the Managed Hub service
- [ ] No objections to the language/scoping here