### PR TITLE
Add pricing and more overview information

### DIFF
--- a/about/2i2c.md
+++ b/about/2i2c.md
@@ -1,8 +1,22 @@
 # About 2i2c
 
-2i2c is a non-profit organization that develops and operates cloud infrastructure for interactive computing in research and education.
+[2i2c](http://2i2c.org) (the International Interactive Computing Collaboration) makes interactive computing more accessible and powerful for research and education. It does so by developing, designing, and managing open source interactive computing infrastructure, and by contributing to open source communities that underlie and create this infrastructure.
+
+:::{admonition} Learn more
+:class: tip
 
 For more information about 2i2c, check out these links:
 
 - [2i2c's public website](https://2i2c.org) contains high-level information about 2i2c and its major projects.
 - [2i2c's Team Compass](https://team-compass.2i2c.org) contains all organizational information about 2i2c, including its structure, governance, strategy, and major projects.
+
+:::
+
+2i2c's engineering team is comprised of [a team of open source infrastructure engineers](http://2i2c.org/about/) with extensive experience working with open source, community-driven projects (particularly in the Jupyter ecosystem). Its strategy is defined by a [steering council](https://2i2c.org/founders/) made of up leaders at the intersection of the Jupyter Project and use-cases in research and education. This group has more than 15 collective years of experience running large-scale cloud infrastructure for interactive computing in university and research contexts. 2i2c’s team are co-leaders and major contributors in many projects in this space, with these notable highlights:
+
+- [The Pangeo project](https://pangeo.io/) - A community platform for Big Data geoscience connecting researchers across the world to large-scale computing and data infrastructure.
+- [The UC Berkeley DataHubs](https://docs.datahub.berkeley.edu/en/latest/) - A collection of university-wide JupyterHubs for education serving many thousands of students.
+- [The Binder Project](https://docs.mybinder.org/) - a large public cloud service for reproducible computing environments using JupyterHub, serving nearly 150,000 sessions each week.
+- [The Syzygy Project](https://syzygy.ca/) - A network of federated JupyterHubs for more than 15 Canadian Universities running on national infrastructure.
+
+For more information about the 2i2c team, see [2i2c.org](https://2i2c.org/about)

--- a/about/index.md
+++ b/about/index.md
@@ -45,7 +45,10 @@ These sections describe the hub service at an organizational level.
 :maxdepth: 1
 :caption: About the Service
 overview
+pricing
+roles
 strategy
 roadmap
 2i2c
+terminology
 ```

--- a/about/overview.md
+++ b/about/overview.md
@@ -14,6 +14,36 @@ They are designed and deployed by the [International Interactive Computing Colla
 4. To use infrastructure that is designed by and for individuals in research and education.
 5. To support infrastructure from a non-profit organization that is committed to communities in research, education, and open source.
 
+(services/overview:what-we-provide)=
+## What will 2i2c provide?
+
+2i2c will operate and manage a 2i2c JupyterHub deployment for use by you and your community, accessible via a web URL. 2i2c will handle the design, configuration, development, and ongoing operation of the hub infrastructure.
+
+The following sections describe several common activities that the 2i2c team will perform as a part of your managed JupyterHub.
+
+### JupyterHub Setup
+
+* Requirement definitions and technical scoping
+* Architectural design
+* Initial deployment on cloud infrastructure
+
+### Ongoing development of hub infrastructure
+
+* Develop customizations needed for the hub deployment
+* Updates to the hub software environment
+* Upgrades and optimizations to 2i2c Hub infrastructure
+
+### Ongoing operation of hub infrastructure
+
+* Debug infrastructure issues, with expedited turnaround time for responses
+* Providing “escalation support” before / during / after the outages and downtime
+* Provide support to hub admins to facilitate their use of the infrastructure
+
+### Development of open source software that underlie the 2i2c Hubs
+
+* Improvements to the Jupyter ecosystem of tools and standards for interactive computing.
+* New features and bug fixes for the tools that are used in a 2i2c Hub
+
 (overview/right-to-replicate)=
 ## Your Right to replicate
 

--- a/about/pricing.md
+++ b/about/pricing.md
@@ -32,41 +32,48 @@ We'll fill in more details in this section as we understand them better, but in 
 
 This is difficult to estimate ahead of time, because it is **heavily** dependent on the primary use-case and size of your community, and because cloud vendors change the cost of their machines often (though they don't change by much).
 
-We recommend checking out [the Zero to JupyterHub cost projection documentation](z2jh:cost), which has a lot of useful background information to understand this.
+We recommend checking out the following resources to learn more about cloud costs.
+None of these are guarantees about costs, but should give you a general idea.
 
-For one example to help you estimate, see the section below.
+- For general information and explanation, see [the Zero to JupyterHub cost projection documentation](z2jh:cost).
+- For educational or "lightweight resources" hubs, see [this rough cost analysis notebook from the UC Berkeley DataHub](https://nbviewer.jupyter.org/github/berkeley-dsep-infra/datahub-usage-analysis/blob/master/notebooks/03-visualize-cost-and-usage.ipynb).
+- For data- and compute-intensive hubs, see the Pangeo two-part series on their Kubernetes costs. ([part 1 link](https://medium.com/pangeo/pangeo-cloud-costs-part1-f89842da411d), [part 2 link](https://medium.com/pangeo/pangeo-cloud-cluster-design-9d58a1bf1ad3))
 
-#### An example with Google Cloud Platform
-
-To get a rough estimate of your cloud costs, here is a rough guide that is based on **Memory (RAM)**. It is a reasonable rule of thumb as long as you don't any particularly complex needs like extremely large datasets or scalable computing/GPUs.
-
-:::{admonition} Other cloud vendors may differ
-This example focuses on Google Cloud Platform.
-There are similar machine types (and generally similar prices) across all of the vendors. You can perform a similar calculation with [AWS](https://calculator.s3.amazonaws.com/index.html) or [Azure](https://azure.microsoft.com/en-us/pricing/calculator/) by following the same steps using a machine that has a similar amount of RAM and CPU as a `e2-highmem4`)
-:::
-
-1. **Read [the Zero to JupyterHub cost projection documentation](z2jh:cost)**. This is a nice high-level overview of the factors that drive the cost of JupyterHub deployments on commercial cloud.
-2. **Estimate memory available to each user**. The amount of RAM needed for each user is often the biggest driver of cloud cost. Decide the "maximum" amount of RAM that a user will generally need, and multiply that by 1.5x.
-3. **Determine how many average simultaneous users you'd like a hub to support**. This isn't necessarily the total size of your community, but how many people you think will be using the hub *at the same time*.
-4. **Look up the monthly price of an `e2-highmem4` machine**. This is a basic machine that is suitable for many use-cases. [Go to the Google Cloud pricing page](https://cloud.google.com/compute/vm-instance-pricing) and go to the `E2 high-memory machine types` section. In that section, look for the `e2-highmem-4` monthly price.
-
-Now calculate a rough estimate of your monthly cloud cost with the following formula:
-
-```
-(n_avg_simultaneous_users * memory_per_user) / 16GB * monthly_price
-```
-
-So for example, if you have a community of **100 total users** but expect an average of only 20 of them to be active at the same time, and each user requires **4GB** of RAM, then with a monthly `e2-highmem4` price of $97.83 (as of {sub-ref}`today`), then your monthly cost will be around:
-
-```
-(20 * 4) / 16 * 97.83 = $489.15 / month or $5,869.80 / year
-```
-
-Or, around **$4.80 per user per month** in cloud costs. If you required **2GB RAM** instead of **4GB RAM**, cloud costs would likely drop to around **$2.40 per user per month**.
-
-:::{warning}
-This is just a rough estimate! As mentioned above, the actual costs will vary from this, but this amount should be correct within an order of magnitude.
-:::
+% TODO: Un-comment this when we think the estimates are acceptable.
+%For one example to help you estimate, see the section below.
+%
+% #### An example with Google Cloud Platform
+% 
+% To get a rough estimate of your cloud costs, here is a rough guide that is based on **Memory (RAM)**. It is a reasonable rule of thumb as long as you don't any particularly % complex needs like extremely large datasets or scalable computing/GPUs.
+% 
+% :::{admonition} Other cloud vendors may differ
+% This example focuses on Google Cloud Platform.
+% There are similar machine types (and generally similar prices) across all of the vendors. You can perform a similar calculation with [AWS](https://calculator.s3.amazonaws.com/% index.html) or [Azure](https://azure.microsoft.com/en-us/pricing/calculator/) by following the same steps using a machine that has a similar amount of RAM and CPU as a % `e2-highmem4`)
+% :::
+% 
+% 1. **Read [the Zero to JupyterHub cost projection documentation](z2jh:cost)**. This is a nice high-level overview of the factors that drive the cost of JupyterHub deployments % on commercial cloud.
+% 2. **Estimate memory available to each user**. The amount of RAM needed for each user is often the biggest driver of cloud cost. Decide the "maximum" amount of RAM that a user % will generally need, and multiply that by 1.5x.
+% 3. **Determine how many average simultaneous users you'd like a hub to support**. This isn't necessarily the total size of your community, but how many people you think will be % using the hub *at the same time*.
+% 4. **Look up the monthly price of an `e2-highmem4` machine**. This is a basic machine that is suitable for many use-cases. [Go to the Google Cloud pricing page](https://cloud.% google.com/compute/vm-instance-pricing) and go to the `E2 high-memory machine types` section. In that section, look for the `e2-highmem-4` monthly price.
+% 
+% Now calculate a rough estimate of your monthly cloud cost with the following formula:
+% 
+% ```
+% (n_avg_simultaneous_users * memory_per_user) / 16GB * monthly_price
+% ```
+% 
+% So for example, if you have a community of **100 total users** but expect an average of only 20 of them to be active at the same time, and each user requires **4GB** of RAM, % then with a monthly `e2-highmem4` price of $97.83 (as of {sub-ref}`today`), then your monthly cost will be around:
+% 
+% ```
+% (20 * 4) / 16 * 97.83 = $489.15 / month or $5,869.80 / year
+% ```
+% 
+% Or, around **$4.80 per user per month** in cloud costs. If you required **2GB RAM** instead of **4GB RAM**, cloud costs would likely drop to around **$2.40 per user per month**.
+% 
+% :::{warning}
+% This is just a rough estimate! As mentioned above, the actual costs will vary from this, but this amount should be correct within an order of magnitude.
+% :::
+% 
 
 ### Who pays for cloud costs?
 

--- a/about/pricing.md
+++ b/about/pricing.md
@@ -32,7 +32,18 @@ We'll fill in more details in this section as we understand them better, but in 
 
 This is difficult to estimate ahead of time, because it is **heavily** dependent on the primary use-case and size of your community, and because cloud vendors change the cost of their machines often (though they don't change by much).
 
+We recommend checking out [the Zero to JupyterHub cost projection documentation](z2jh:cost), which has a lot of useful background information to understand this.
+
+For one example to help you estimate, see the section below.
+
+#### An example with Google Cloud Platform
+
 To get a rough estimate of your cloud costs, here is a rough guide that is based on **Memory (RAM)**. It is a reasonable rule of thumb as long as you don't any particularly complex needs like extremely large datasets or scalable computing/GPUs.
+
+:::{admonition} Other cloud vendors may differ
+This example focuses on Google Cloud Platform.
+There are similar machine types (and generally similar prices) across all of the vendors. You can perform a similar calculation with [AWS](https://calculator.s3.amazonaws.com/index.html) or [Azure](https://azure.microsoft.com/en-us/pricing/calculator/) by following the same steps using a machine that has a similar amount of RAM and CPU as a `e2-highmem4`)
+:::
 
 1. **Read [the Zero to JupyterHub cost projection documentation](z2jh:cost)**. This is a nice high-level overview of the factors that drive the cost of JupyterHub deployments on commercial cloud.
 2. **Estimate memory available to each user**. The amount of RAM needed for each user is often the biggest driver of cloud cost. Decide the "maximum" amount of RAM that a user will generally need, and multiply that by 1.5x.

--- a/about/pricing.md
+++ b/about/pricing.md
@@ -1,0 +1,72 @@
+# Pricing
+
+The fee for the 2i2c Hub Service is paid monthly. This covers the services provided as described above.
+The cost of the hub service is highly dependent on the use-case, complexity of the environment, and cloud resources that are needed.
+In the alpha phase, 2i2c’s goal is to offer hubs at a bespoke price that is sustainable for both us and the communities we serve.
+
+:::{admonition} If you’d like a quote
+If you'd like a quote for estimated cloud costs and the management fee for your hub service, please fill out [this Google form to understand your use-case](https://docs.google.com/forms/d/e/1FAIpQLSepevnAiyN7ECZqTvTd5W7H6AePv7t5APnqTZ3r2D8gp1Nepw/viewform?usp=sf_link).
+:::
+
+There are two major components to the price of 2i2c's Managed JupyterHubs service: DevOps fees, and Cloud Costs.
+We give an overview of major considerations for each below.
+
+## DevOps costs
+
+2i2c provides "DevOps as a Service" for the communities that it serves.
+This means that we design, operate, develop, and support the cloud infrastructure that powers each JupyterHub.
+For a more in-depth description of what this entails, see [](services/overview:what-we-provide).
+
+As the 2i2c Managed JupyterHubs service is in an `alpha` stage, we are still researching and understanding what the price of these DevOps services will be.
+We'll fill in more details in this section as we understand them better, but in the meantime here are a few guidelines that we'll use for our pricing:
+
+2i2c DevOps fees should be:
+
+- Competitive with other "Data Science environment as a service" offerings.
+- An amount that is sustainable for the communities we serve, with mechanisms to accommodate institutions with fewer resources.
+- An amount that allows 2i2c to both sustain itself and thrive, and covers our time developing and supporting open source projects as part of the service.
+
+## Cloud costs
+
+### How much will my cloud costs be?
+
+This is difficult to estimate ahead of time, because it is **heavily** dependent on the primary use-case and size of your community, and because cloud vendors change the cost of their machines often (though they don't change by much).
+
+To get a rough estimate of your cloud costs, here is a rough guide that is based on **Memory (RAM)**. It is a reasonable rule of thumb as long as you don't any particularly complex needs like extremely large datasets or scalable computing/GPUs.
+
+1. **Read [the Zero to JupyterHub cost projection documentation](z2jh:cost)**. This is a nice high-level overview of the factors that drive the cost of JupyterHub deployments on commercial cloud.
+2. **Estimate memory available to each user**. The amount of RAM needed for each user is often the biggest driver of cloud cost. Decide the "maximum" amount of RAM that a user will generally need, and multiply that by 1.5x.
+3. **Determine how many average simultaneous users you'd like a hub to support**. This isn't necessarily the total size of your community, but how many people you think will be using the hub *at the same time*.
+4. **Look up the monthly price of an `e2-highmem4` machine**. This is a basic machine that is suitable for many use-cases. [Go to the Google Cloud pricing page](https://cloud.google.com/compute/vm-instance-pricing) and go to the `E2 high-memory machine types` section. In that section, look for the `e2-highmem-4` monthly price.
+
+Now calculate a rough estimate of your monthly cloud cost with the following formula:
+
+```
+(n_avg_simultaneous_users * memory_per_user) / 16GB * monthly_price
+```
+
+So for example, if you have a community of **100 total users** but expect an average of only 20 of them to be active at the same time, and each user requires **4GB** of RAM, then with a monthly `e2-highmem4` price of $97.83 (as of {sub-ref}`today`), then your monthly cost will be around:
+
+```
+(20 * 4) / 16 * 97.83 = $489.15 / month or $5,869.80 / year
+```
+
+Or, around **$4.80 per user per month** in cloud costs. If you required **2GB RAM** instead of **4GB RAM**, cloud costs would likely drop to around **$2.40 per user per month**.
+
+:::{warning}
+This is just a rough estimate! As mentioned above, the actual costs will vary from this, but this amount should be correct within an order of magnitude.
+:::
+
+### Who pays for cloud costs?
+
+You should pay *only* for the cloud costs you actually incur, and you should have control over the financial resources available to run your infrastructure.
+2i2c has two approaches to handle cloud billing:
+
+**You manage billing, we manage infrastructure.** If you’d like to manage your own cloud billing, or have credits to use, simply give us permissions to run infrastructure that uses this account. 2i2c is then not involved in managing your cloud bill at all. We can provide guidance for setting up alerts / checkpoints on the billing if you wish.
+
+**We manage both billing and infrastructure.** If you wish that 2i2c also manage cloud billing for the Hub infrastructure, 2i2c will manage a billing account for you (and give you administrative access to it). We will send you an additional “Cloud Billing” invoice. This will be used to purchase credits that are used to run your hub’s infrastructure.
+
+```{figure} https://drive.google.com/uc?export=download&id=1PU2qBZH_nzIGI1-16vBMsdWE6gPqqz-P
+
+An overview of our cloud pricing options and how 2i2c fits in with each.
+```

--- a/about/roles.md
+++ b/about/roles.md
@@ -1,0 +1,58 @@
+# Roles for the service
+
+There are a few major roles that we define for the Managed JupyterHub Service.
+These are outlined below.
+
+```{figure} https://drive.google.com/uc?export=download&id=1sT3pSgMePpsnQKUNih0gLUsJWqG2os1D
+A short overview of the major roles that participate in the Managed JupyterHub Service
+```
+
+(roles:community-representative)=
+## Community Representative
+
+The job of a Community Representative is to ensure that the interests of the {term}`Hub Community` are represented in the infrastructure, and that the hub serves their needs.
+There must be **one or two community representatives for a given community**.
+This role is usually filled by someone that is a member of the hub's community of practice.
+
+### Responsibilities
+
+- The main point of contact between the hub engineer and the {term}`Hub Community`.
+- Collect feedback and questions from users on a hub.
+- Surface questions and requests to Hub Engineers via support tickets.
+- Oversee the [Hub Administrators](roles:hub-administrator)
+
+
+(roles:hub-administrator)=
+## Hub Administrator
+
+The job of hub administrators is to support users and to perform common administrative operations on a hub that do not require intervention from a [Hub Engineer](roles:hub-engineer).
+[Community Representatives](roles:community-representative) are the first Hub Administrators, and they may add new Hub Administrators via the JupyterHub interface.
+They are able to add users, start/stop servers, and generally have more control over operations on the hub.
+
+:::{seealso}
+See the [Hub Administrator's guide](/admin/index) for helpful information for Hub Administrators.
+:::
+
+:::{warning}
+Only give this role to people you trust, as they can perform disruptive actions for other users.
+:::
+
+### Responsibilities
+
+- Provide support to users of a hub for common problems that don't require a Hub Engineer to resolve.
+- Add new users to a hub, including administrative users.
+- Surface major issues or requests to the Community Representative(s).
+
+(roles:hub-engineer)=
+## Hub Engineer
+
+The job of a Hub Engineer is to develop and operate deployment infrastructure for a hub, and to perform major upgrades or improvements to resolve issues that cannot be solved by a [Hub Administrator](roles:hub-administrator).
+Hub engineers regularly work on the JupyterHub infrastructure and provide open source development for the technology that powers each hub.
+People in these roles are generally affiliated with 2i2c.
+
+### Responsibilities
+
+- Respond to support requests from the Community Representative(s)
+- Perform major upgrades on hub infrastructure
+- Debug and resolve major issues with a hub that require intervention from a Hub Engineer
+- Perform open source development on technologies that are in use by the hubs

--- a/about/services/overview.md
+++ b/about/services/overview.md
@@ -26,19 +26,6 @@ See [our strategy page](../strategy.md) for an overview of what we're hoping to 
 📦 data
 : The data that is used by your 2i2c JupyterHub is provided by you! 2i2c JupyterHubs can connect with a variety of public data sources. We recommend using standard data structures or specifications via libraries like [Intake](https://intake.readthedocs.io/en/latest/). Note that 2i2c does not host this data itself, but can build connections between 2i2c JupyterHubs and these data sources.
 
-(note-on-urls)=
-## Where are hubs accessed?
-
-By default all 2i2c JupyterHub get their own URL with the following form:
-
-```
-<hub-name>.<community-name>.2i2c.cloud
-```
-
-Each 2i2c JupyterHub has **hub name** (denoted by `<hub-name>`) and a **community name** (denoted by `<community-name>`). Communities are collections of hubs around a particular community or collaboration. Each community infrastructure may be run by different teams. For more information, see [](people-behind-hubs).
-
-It is also possible to provide your own URL that points to a 2i2c JupyterHub.
-
 ## Features of each hub
 
 Here is a brief overview of the major features that are present in each.
@@ -67,6 +54,27 @@ Here is a brief overview of the major features that are present in each.
         background-color: #f8f9fa;
     }
 </style>
+
+(note-on-urls)=
+## Where are hubs accessed?
+
+By default all 2i2c JupyterHub get their own URL with the following form:
+
+```
+<hub-name>.<community-name>.2i2c.cloud
+```
+
+Each 2i2c JupyterHub has **hub name** (denoted by `<hub-name>`) and a **community name** (denoted by `<community-name>`). Communities are collections of hubs around a particular community or collaboration. Each community infrastructure may be run by different teams. For more information, see [](people-behind-hubs).
+
+It is also possible to provide your own URL that points to a 2i2c JupyterHub.
+
+## Will 2i2c keep information about a hub's users?
+
+2i2c will not collect user data for any purpose. 2i2c will have access to all of the information that is inside a hub (which it requires in order to debug problems and and assist with upgrades), however we will not retain any of this data or move it *outside* of the hub, and will not retain it once the hub is shut down (except in order to transfer data to you at your request).
+
+## Data outside of the hub
+
+If you wish to access data that exists outside of your 2i2c Hub, it is your responsibility to put this data in the cloud and manage the infrastructure around it. 2i2c does not control this data, it merely provides access to it via your hub infrastructure.
 
 ## Where are hubs configured and deployed?
 

--- a/about/terminology.md
+++ b/about/terminology.md
@@ -1,0 +1,23 @@
+# Terminology reference
+
+:::{glossary}
+
+Project Jupyter  
+    A community-supported project that builds a variety of tools for interactive computing - from user interfaces, to document formats, to cloud infrastructure. Project Jupyter is one of the most-impactful open source projects in data science in the last ten years, and was awarded the [ACM Software System award](https://blog.jupyter.org/jupyter-receives-the-acm-software-system-award-d433b0dfe3a2) for its impact.
+
+JupyterHub
+    [JupyterHub](https://jupyterhub.readthedocs.io/) is an open-source project for providing and managing interactive computing sessions to multiple users, usually deployed on shared infrastructure.
+
+JupyterHub for Kubernetes
+    [JupyterHub for Kubernetes](http://z2jh.jupyter.org) is a distribution of JupyterHub designed for use with the scalable Kubernetes platform. Kubernetes is cloud- and infrastructure-agnostic, and is flexible enough to scale to large numbers of users and complex computational needs.
+
+Jupyter Interfaces
+Jupyter Notebooks and JupyterLab
+    [Jupyter Notebooks / Lab](http://jupyterlab.readthedocs.io/) are open-source user interfaces for doing interactive data analysis. Notebooks provide an opinionated, linear, document-like workflow, while Lab provides a more flexible and composable interface.
+
+Right to Replicate
+    The [Right to Replicate](https://2i2c.org/right-to-replicate/) is a guiding principle of 2i2c Hub infrastructure. It gives communities the right to replicate their infrastructure in its  entirety elsewhere, with or without 2i2c. It entails running infrastructure that is open-source and vendor-agnostic, and in an open and transparent manner. See the [Right to Replicate](https://2i2c.org/right-to-replicate/) document for more details.
+
+Hub Community
+    The community of practice that a Managed JupyterHub serves. This includes leadership of the community as well as users of the hub. The Hub Community is usually organized around a particular use-case or dataset, and may or may not be affiliated with the same organization.
+:::

--- a/conf.py
+++ b/conf.py
@@ -65,7 +65,8 @@ html_baseurl = "https://2i2c.org/pilot"
 intersphinx_mapping = {
     "tc": ('https://team-compass.2i2c.org/en/latest', None),
     "ph": ('https://pilot-hubs.2i2c.org/en/latest', None),
-    "jb": ('https://jupyterbook.org', None)
+    "jb": ('https://jupyterbook.org', None),
+    "z2jh": ('https://z2jh.jupyter.org/en/latest', None),
 }
 
 rediraffe_redirects = {


### PR DESCRIPTION
This adds some more core information about the Hub Service to our documentation. It adds these major sections:

- Pricing guidelines
  - This includes a very rough cloud costs calculator. It tries to overestimate the costs a bit.
- An overview of what "DevOps as a Service" things we provide
- An overview of roles that are needed in a hub
- A page with terminology and background